### PR TITLE
support data-range for timeseries

### DIFF
--- a/unittest/test_util.py
+++ b/unittest/test_util.py
@@ -1,7 +1,13 @@
+from datetime import datetime
+
+import pandas as pd
 import pytest
+import pytz
 
 from wapi.curves import TimeSeriesCurve
-from wapi.util import TS
+from wapi.util import TS, Range
+
+CET = pytz.timezone('CET')
 
 
 @pytest.fixture
@@ -28,12 +34,12 @@ def ts3():
               time_zone='CET', curve_type=TimeSeriesCurve, points=points)
 
 
-def test_to_pandas(ts1):
+def test_ts_to_pandas(ts1):
     pd_series = ts1.to_pandas()
     assert len(pd_series.index) == len(ts1.points)
 
 
-def test_from_pandas(ts1):
+def test_ts_from_pandas(ts1):
     pd_series = ts1.to_pandas()
     re_ts = TS.from_pandas(pd_series)
 
@@ -45,7 +51,7 @@ def test_from_pandas(ts1):
         assert dp1 == dp2
 
 
-def test_sum_ts(ts1, ts2, ts3):
+def test_ts_sum_ts(ts1, ts2, ts3):
     points = [[0, 420], [2678400000, 420],
               [5097600000, 540], [7776000000, 1080]]
     sum_name = 'Summed Series'
@@ -60,7 +66,7 @@ def test_sum_ts(ts1, ts2, ts3):
         assert dp1 == dp2
 
 
-def test_mean_ts(ts1, ts2, ts3):
+def test_ts_mean_ts(ts1, ts2, ts3):
     points = [[0, 140.0], [2678400000, 140],
               [5097600000, 180], [7776000000, 360]]
     mean_name = 'Mean Series'
@@ -75,7 +81,7 @@ def test_mean_ts(ts1, ts2, ts3):
         assert dp1 == dp2
 
 
-def test_median_ts(ts1, ts2, ts3):
+def test_ts_median_ts(ts1, ts2, ts3):
     points = [[0, 120.0], [2678400000, 120],
               [5097600000, 140], [7776000000, 380]]
     median_name = 'Median Series'
@@ -88,3 +94,44 @@ def test_median_ts(ts1, ts2, ts3):
 
     for dp1, dp2 in zip(points, summed.points):
         assert dp1 == dp2
+
+
+def test_range_range_dict_non_empty():
+    response = {
+        'begin': '2009-12-31T23:00:00+00:00',
+        'end': '2022-09-29T22:00:00+00:00'
+    }
+    r = Range.from_dict(response)
+    assert '2010-01-01T00:00:00+01:00' == r.begin.isoformat()
+    assert '2022-09-30T00:00:00+02:00' == r.end.isoformat()
+
+
+def test_range_range_dict_empty():
+    assert Range.from_dict({}) == Range(None, None)
+
+
+def test_range_is_finite():
+    r = Range(
+        CET.localize(datetime(2010, 1, 1, 1)),
+        CET.localize(datetime(2022, 9, 30))
+    )
+    assert r.is_finite()
+
+    r = Range(None, CET.localize(datetime(2022, 9, 30)))
+    assert not r.is_finite()
+
+    r = Range(CET.localize(datetime(2022, 9, 30)), None)
+    assert not r.is_finite()
+
+    r = Range(None, None)
+    assert not r.is_finite()
+
+
+def test_range_to_pandas():
+    r = Range(
+        CET.localize(datetime(2010, 1, 1, 1)),
+        CET.localize(datetime(2022, 8, 30))
+    )
+    interval: pd.Interval = r.to_pandas()
+    assert interval.left == pd.Timestamp(2010, 1, 1, 1).tz_localize(CET)
+    assert interval.right == pd.Timestamp(2022, 8, 30).tz_localize(CET)

--- a/unittest/wapi_tests.py
+++ b/unittest/wapi_tests.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import os
 
@@ -174,6 +175,26 @@ def test_ts_data(ts_curve):
     d = c.get_data(data_from=1, data_to=2)
     assert isinstance(d, wapi.util.TS)
     assert d.frequency == 'H'
+
+
+@pytest.mark.parametrize('range_begin, range_end, tz', [
+    ('2022-09-07T00:00:00+02:00', '2022-09-10T22:00:00+02:00', None),
+    ('2022-09-06T22:00:00Z', '2022-09-10T20:00:00Z', 'CET')
+
+])
+def test_ts_data_range(ts_curve, range_begin, range_end, tz):
+    c, s, m = ts_curve
+    result = {
+        'begin': range_begin,
+        'end': range_end
+    }
+    m.register_uri('GET', f'{prefix}/series/5/range', text=json.dumps(result))
+    range = c.get_data_range(output_time_zone=tz)
+    assert isinstance(range, wapi.util.Range)
+    assert isinstance(range.begin, datetime.datetime)
+    assert isinstance(range.end, datetime.datetime)
+    assert '2022-09-07T00:00:00+02:00' == range.begin.isoformat()
+    assert '2022-09-10T22:00:00+02:00' == range.end.isoformat()
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR adds support to get the data range of timeseries curves.

Dependency:
* [ ] The endpoint has to be available in the API before this client code can be merged.