### PR TITLE
fix: stack overflow recursion when token expires

### DIFF
--- a/unittest/test_session.py
+++ b/unittest/test_session.py
@@ -35,14 +35,14 @@ def test_data_request__get_auth__ok(requests_mock, auth_mock):
     assert response == mock_response
 
 @patch.object(wapi.session.requests.Session, "request")
-def test_data_request__token_expire__ok(fake_request):
-    def my_side_effect(**kwargs):
+def test_data_request__token_expire__ok(mock_request):
+    def mock_request_effect(**kwargs):
         if kwargs["method"] == "POST":
             return MockResponse(200, content=json.dumps({"access_token": "a", "token_type": "b", "expires_in": 10}).encode())
         elif kwargs["method"] == "GET":
             return MockResponse(200, "curves")
 
-    fake_request.side_effect = my_side_effect
+    mock_request.side_effect = mock_request_effect
     wapi.session.RETRY_DELAY = 0.00001
 
     # verify auth getting token at beginning

--- a/unittest/test_session.py
+++ b/unittest/test_session.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, MagicMock
 
 import pytest
 import requests
@@ -18,19 +18,14 @@ def make_wapi_session():
                                 client_id='client1',
                                 client_secret='secret1')
 
-
-
-
-@patch('wapi.session.auth')
+# ignore auth
+@patch('wapi.session.auth', MagicMock())
 @patch('wapi.session.requests')
-def test_data_request__get_auth__ok(requests_mock, auth_mock):
+def test_data_request__get__ok(requests_mock):
     mock_response = MockResponse(200)
     req_session_mock = Mock()
     req_session_mock.request.return_value = mock_response
     requests_mock.Session.return_value = req_session_mock
-    oauth_mock = Mock()
-    auth_mock.OAuth.return_value = oauth_mock
-    oauth_mock.get_headers.return_value = {'Authorization': 'X Y'}
 
     session = make_wapi_session()
     response = session.data_request('GET', None, '/curves')
@@ -60,17 +55,18 @@ def test_data_request__token_expire__ok(mock_request):
     assert session.auth.get_headers(None) == {'Authorization': 'b a'}
 
 
-@pytest.mark.parametrize("urlbase,url,longurl_expected", [(None, "/token", "https://volueinsight.com/token"), ("http://urlbase", "/token", "http://urlbase/token")])
-@patch('wapi.session.auth')
+@pytest.mark.parametrize("urlbase,url,longurl_expected", 
+    [
+        (None, "/token", "https://volueinsight.com/token"), 
+        ("http://urlbase", "/token", "http://urlbase/token")
+    ])
+@patch('wapi.session.auth', MagicMock())
 @patch('wapi.session.requests')
-def test_send_data_request__long_url__correct(requests_mock, auth_mock, urlbase, url, longurl_expected):
+def test_send_data_request__long_url__correct(requests_mock, urlbase, url, longurl_expected):
     mock_response = MockResponse(200)
     req_session_mock = Mock()
     req_session_mock.request.return_value = mock_response
     requests_mock.Session.return_value = req_session_mock
-    oauth_mock = Mock()
-    auth_mock.OAuth.return_value = oauth_mock
-    oauth_mock.get_headers.return_value = {'Authorization': 'X Y'}
 
     session = make_wapi_session()    
     session.data_request('GET', urlbase=urlbase, url=url)
@@ -78,17 +74,19 @@ def test_send_data_request__long_url__correct(requests_mock, auth_mock, urlbase,
     call_args = req_session_mock.request.call_args
     assert call_args[1]["url"] == longurl_expected
 
-@pytest.mark.parametrize("data,rawdata,databytes_expected", [(None, "rawdata", "rawdata"), (40, None, b"40"), ("basestring", "rawdata", b"basestring")])
-@patch('wapi.session.auth')
+@pytest.mark.parametrize("data,rawdata,databytes_expected", 
+    [
+        (None, "rawdata", "rawdata"), 
+        (40, None, b"40"), 
+        ("basestring", "rawdata", b"basestring")
+    ])
+@patch('wapi.session.auth', MagicMock())
 @patch('wapi.session.requests')
-def test_send_data_request__databytes__correct(requests_mock, auth_mock, data, rawdata, databytes_expected):
+def test_send_data_request__databytes__correct(requests_mock, data, rawdata, databytes_expected):
     mock_response = MockResponse(200)
     req_session_mock = Mock()
     req_session_mock.request.return_value = mock_response
     requests_mock.Session.return_value = req_session_mock
-    oauth_mock = Mock()
-    auth_mock.OAuth.return_value = oauth_mock
-    oauth_mock.get_headers.return_value = {'Authorization': 'X Y'}
 
     session =  make_wapi_session()   
     session.data_request('GET', None, None, data=data, rawdata=rawdata)
@@ -97,16 +95,13 @@ def test_send_data_request__databytes__correct(requests_mock, auth_mock, data, r
     assert call_args[1]["data"] == databytes_expected
 
 @pytest.mark.parametrize("status_code", [408, 500, 599])
-@patch('wapi.session.auth')
+@patch('wapi.session.auth', MagicMock())
 @patch('wapi.session.requests')
-def test_send_data_request__retries__correct(requests_mock, auth_mock, status_code):
+def test_send_data_request__retries__correct(requests_mock, status_code):
     mock_response_fail = MockResponse(status_code)
     req_session_mock = Mock()
     req_session_mock.request.return_value = mock_response_fail
     requests_mock.Session.return_value = req_session_mock
-    oauth_mock = Mock()
-    auth_mock.OAuth.return_value = oauth_mock
-    oauth_mock.get_headers.return_value = {'Authorization': 'X Y'}
 
     retries_count = 3
     wapi.session.RETRY_DELAY = 0.00001

--- a/unittest/test_session.py
+++ b/unittest/test_session.py
@@ -11,6 +11,7 @@ class MockResponse:
     def __init__(self, status_code, content="Mock content"):
         self.status_code = status_code
         self.content = content
+        
 
 def make_wapi_session():
     return wapi.session.Session(urlbase='https://volueinsight.com',
@@ -23,14 +24,14 @@ def make_wapi_session():
 @patch('wapi.session.requests')
 def test_data_request__get__ok(requests_mock):
     mock_response = MockResponse(200)
-    req_session_mock = Mock()
-    req_session_mock.request.return_value = mock_response
-    requests_mock.Session.return_value = req_session_mock
+    # https://docs.python.org/3/library/unittest.mock-examples.html#mocking-chained-calls
+    requests_mock.Session.return_value.request.return_value = mock_response
 
     session = make_wapi_session()
     response = session.data_request('GET', None, '/curves')
 
     assert response == mock_response
+
 
 @patch.object(wapi.session.requests.Session, "request")
 def test_data_request__token_expire__ok(mock_request):
@@ -63,16 +64,14 @@ def test_data_request__token_expire__ok(mock_request):
 @patch('wapi.session.auth', MagicMock())
 @patch('wapi.session.requests')
 def test_send_data_request__long_url__correct(requests_mock, urlbase, url, longurl_expected):
-    mock_response = MockResponse(200)
-    req_session_mock = Mock()
-    req_session_mock.request.return_value = mock_response
-    requests_mock.Session.return_value = req_session_mock
+    requests_mock.Session.return_value.request.return_value = MockResponse(200)
 
     session = make_wapi_session()    
     session.data_request('GET', urlbase=urlbase, url=url)
 
-    call_args = req_session_mock.request.call_args
+    call_args = requests_mock.Session.return_value.request.call_args
     assert call_args[1]["url"] == longurl_expected
+
 
 @pytest.mark.parametrize("data,rawdata,databytes_expected", 
     [
@@ -83,43 +82,37 @@ def test_send_data_request__long_url__correct(requests_mock, urlbase, url, longu
 @patch('wapi.session.auth', MagicMock())
 @patch('wapi.session.requests')
 def test_send_data_request__databytes__correct(requests_mock, data, rawdata, databytes_expected):
-    mock_response = MockResponse(200)
-    req_session_mock = Mock()
-    req_session_mock.request.return_value = mock_response
-    requests_mock.Session.return_value = req_session_mock
+    requests_mock.Session.return_value.request.return_value = MockResponse(200)
 
     session =  make_wapi_session()   
     session.data_request('GET', None, None, data=data, rawdata=rawdata)
 
-    call_args = req_session_mock.request.call_args
+    call_args = requests_mock.Session.return_value.request.call_args
     assert call_args[1]["data"] == databytes_expected
 
-@pytest.mark.parametrize("status_code", [408, 500, 599])
+
+@pytest.mark.parametrize("failed_status_code", [408, 500, 599])
 @patch('wapi.session.auth', MagicMock())
 @patch('wapi.session.requests')
-def test_send_data_request__retries__correct(requests_mock, status_code):
-    mock_response_fail = MockResponse(status_code)
-    req_session_mock = Mock()
-    req_session_mock.request.return_value = mock_response_fail
-    requests_mock.Session.return_value = req_session_mock
+def test_send_data_request__retries__correct(requests_mock, failed_status_code):
+    requests_mock.Session.return_value.request.return_value = MockResponse(failed_status_code)
 
     retries_count = 3
     wapi.session.RETRY_DELAY = 0.00001
     session =  make_wapi_session()   
     session.send_data_request("GET", "http://urlbase", "/url", "data", None, "headers", "authval", False, retries_count)
 
-    call_args = req_session_mock.request.call_args
+    call_args = requests_mock.Session.return_value.request.call_args
     assert call_args[1] == {"method": "GET", "url": "http://urlbase/url", "data": b"data", "headers": "headers", 
                             "auth": "authval", "stream": False, "timeout": 300}
-    assert req_session_mock.request.call_count == retries_count + 1
+    assert requests_mock.Session.return_value.request.call_count == retries_count + 1
+
 
 @patch('wapi.session.auth')
 @patch('wapi.session.requests')
 def test_data_request__get_auth__first_failed_then_ok(requests_mock, auth_mock):
     mock_response = MockResponse(200)
-    req_session_mock = Mock()
-    req_session_mock.request.return_value = mock_response
-    requests_mock.Session.return_value = req_session_mock
+    requests_mock.Session.return_value.request.return_value = mock_response
     oauth_mock = Mock()
     auth_mock.OAuth.return_value = oauth_mock
     validation_called = []
@@ -142,8 +135,8 @@ def test_data_request__get_auth__first_failed_then_ok(requests_mock, auth_mock):
     assert response == mock_response
 
     assert len(validation_called) == 2
-    assert req_session_mock.request.call_count == 1
-    call_args = req_session_mock.request.call_args
+    assert requests_mock.Session.return_value.request.call_count == 1
+    call_args = requests_mock.Session.return_value.request.call_args
     assert call_args[1]['method'] == "GET"
     assert call_args[1]['headers'] == {'Authorization': 'X Y'}
 
@@ -152,9 +145,7 @@ def test_data_request__get_auth__first_failed_then_ok(requests_mock, auth_mock):
 @patch('wapi.session.requests')
 def test_data_request__fail_too_many_times(requests_mock, auth_mock):
     mock_response = MockResponse(200)
-    req_session_mock = Mock()
-    req_session_mock.request.return_value = mock_response
-    requests_mock.Session.return_value = req_session_mock
+    requests_mock.Session.return_value.request.return_value = mock_response
     oauth_mock = Mock()
     auth_mock.OAuth.return_value = oauth_mock
     validation_called = []
@@ -174,5 +165,5 @@ def test_data_request__fail_too_many_times(requests_mock, auth_mock):
         session.data_request('GET', None, '/curves')
 
     assert len(validation_called) == 5
-    assert req_session_mock.request.call_count == 0
+    assert requests_mock.Session.return_value.request.call_count == 0
 

--- a/wapi/auth.py
+++ b/wapi/auth.py
@@ -49,7 +49,7 @@ class OAuth:
         url = urljoin(self.auth_urlbase, '/oauth2/token')
         auth = (self.client_id, self.client_secret)
         data = {'grant_type': 'client_credentials'}
-        response = self.session.data_request('POST', self.auth_urlbase, url, rawdata=data, authval=auth)
+        response = self.session.send_data_request('POST', self.auth_urlbase, url, rawdata=data, authval=auth)
         if response.status_code != 200:
             raise AuthFailedException('Authentication failed: {}'.format(response.content))
         # Parse token

--- a/wapi/session.py
+++ b/wapi/session.py
@@ -503,45 +503,6 @@ class Session(object):
         res = self.send_data_request(req_type, urlbase, url, data, rawdata, headers, authval, stream, retries)
         return res
 
-        # # # # # 
-        # headers = {}
-
-        # if not urlbase:
-        #     urlbase = self.urlbase
-        # longurl = urljoin(urlbase, url)
-
-        # databytes = None
-        # if data is not None:
-        #     headers['content-type'] = 'application/json'
-        #     if isinstance(data, basestring):
-        #         databytes = data.encode()
-        #     else:
-        #         databytes = json.dumps(data).encode()
-        # if data is None and rawdata is not None:
-        #     databytes = rawdata
-        # if self.auth is not None:
-        #     # Beta-feature: Only update auth with retry if explicitly requested
-        #     if self.retry_update_auth:
-        #         auth_header = self._get_auth_header_with_retry(databytes)
-        #         headers.update(auth_header)
-        #     else:
-        #         self.auth.validate_auth()
-        #         headers.update(self.auth.get_headers(databytes))
-        # timeout = None
-        # try:
-        #     res = self._session.request(method=req_type, url=longurl, data=databytes,
-        #                                 headers=headers, auth=authval, stream=stream, timeout=self.timeout)
-        # except requests.exceptions.Timeout as e:
-        #     timeout = e
-        #     res = None
-        # if (timeout is not None or (500 <= res.status_code < 600) or res.status_code == 408) and retries > 0:
-        #     if RETRY_DELAY > 0:
-        #         time.sleep(RETRY_DELAY)
-        #     return self.data_request(req_type, urlbase, url, data, rawdata, authval, stream, retries-1)
-        # if timeout is not None:
-        #     raise timeout
-        # return res
-
     def handle_single_curve_response(self, response):
         if not response.ok:
             raise MetadataException('Failed to load curve: {}'

--- a/wapi/session.py
+++ b/wapi/session.py
@@ -442,14 +442,8 @@ class Session(object):
                 time.sleep(RETRY_DELAY)
             return self._get_auth_header_with_retry(databytes, retries - 1)
 
-    def data_request(self, req_type, urlbase, url, data=None, rawdata=None, authval=None,
-                     stream=False, retries=RETRY_COUNT):
-        """Run a call to the backend, dealing with authentication etc."""
+    def _validate_auth(self, data, rawdata):
         headers = {}
-
-        if not urlbase:
-            urlbase = self.urlbase
-        longurl = urljoin(urlbase, url)
 
         databytes = None
         if data is not None:
@@ -468,6 +462,23 @@ class Session(object):
             else:
                 self.auth.validate_auth()
                 headers.update(self.auth.get_headers(databytes))
+        
+        return headers
+    
+    def send_data_request(self, req_type, urlbase, url, data=None, rawdata=None, headers=None, authval=None,
+                     stream=False, retries=RETRY_COUNT):
+        if not urlbase:
+            urlbase = self.urlbase
+        longurl = urljoin(urlbase, url)
+
+        databytes = None
+        if data is not None:
+            if isinstance(data, basestring):
+                databytes = data.encode()
+            else:
+                databytes = json.dumps(data).encode()
+        if data is None and rawdata is not None:
+            databytes = rawdata
         timeout = None
         try:
             res = self._session.request(method=req_type, url=longurl, data=databytes,
@@ -478,10 +489,58 @@ class Session(object):
         if (timeout is not None or (500 <= res.status_code < 600) or res.status_code == 408) and retries > 0:
             if RETRY_DELAY > 0:
                 time.sleep(RETRY_DELAY)
-            return self.data_request(req_type, urlbase, url, data, rawdata, authval, stream, retries-1)
+            return self.send_data_request(req_type, urlbase, url, data, rawdata, authval, stream, retries-1)
         if timeout is not None:
             raise timeout
         return res
+
+
+
+    def data_request(self, req_type, urlbase, url, data=None, rawdata=None, authval=None,
+                     stream=False, retries=RETRY_COUNT):
+        """Run a call to the backend, dealing with authentication etc."""
+        headers = self._validate_auth(data, rawdata)
+        res = self.send_data_request(req_type, urlbase, url, data, rawdata, headers, authval, stream, retries)
+        return res
+
+        # # # # # 
+        # headers = {}
+
+        # if not urlbase:
+        #     urlbase = self.urlbase
+        # longurl = urljoin(urlbase, url)
+
+        # databytes = None
+        # if data is not None:
+        #     headers['content-type'] = 'application/json'
+        #     if isinstance(data, basestring):
+        #         databytes = data.encode()
+        #     else:
+        #         databytes = json.dumps(data).encode()
+        # if data is None and rawdata is not None:
+        #     databytes = rawdata
+        # if self.auth is not None:
+        #     # Beta-feature: Only update auth with retry if explicitly requested
+        #     if self.retry_update_auth:
+        #         auth_header = self._get_auth_header_with_retry(databytes)
+        #         headers.update(auth_header)
+        #     else:
+        #         self.auth.validate_auth()
+        #         headers.update(self.auth.get_headers(databytes))
+        # timeout = None
+        # try:
+        #     res = self._session.request(method=req_type, url=longurl, data=databytes,
+        #                                 headers=headers, auth=authval, stream=stream, timeout=self.timeout)
+        # except requests.exceptions.Timeout as e:
+        #     timeout = e
+        #     res = None
+        # if (timeout is not None or (500 <= res.status_code < 600) or res.status_code == 408) and retries > 0:
+        #     if RETRY_DELAY > 0:
+        #         time.sleep(RETRY_DELAY)
+        #     return self.data_request(req_type, urlbase, url, data, rawdata, authval, stream, retries-1)
+        # if timeout is not None:
+        #     raise timeout
+        # return res
 
     def handle_single_curve_response(self, response):
         if not response.ok:

--- a/wapi/session.py
+++ b/wapi/session.py
@@ -494,7 +494,6 @@ class Session(object):
             raise timeout
         return res
 
-
     def data_request(self, req_type, urlbase, url, data=None, rawdata=None, authval=None,
                      stream=False, retries=RETRY_COUNT):
         """Run a call to the backend, dealing with authentication etc."""

--- a/wapi/session.py
+++ b/wapi/session.py
@@ -489,11 +489,10 @@ class Session(object):
         if (timeout is not None or (500 <= res.status_code < 600) or res.status_code == 408) and retries > 0:
             if RETRY_DELAY > 0:
                 time.sleep(RETRY_DELAY)
-            return self.send_data_request(req_type, urlbase, url, data, rawdata, authval, stream, retries-1)
+            return self.send_data_request(req_type, urlbase, url, data, rawdata, headers, authval, stream, retries-1)
         if timeout is not None:
             raise timeout
         return res
-
 
 
     def data_request(self, req_type, urlbase, url, data=None, rawdata=None, authval=None,


### PR DESCRIPTION
When token expires and `auth` tries to get a new one, there will be an error with 

`RecursionError: maximum recursion depth exceeded while calling a Python object`

The reason is because currently `Session.data_request` and `Auth.validate_auth` are calling each other. With the removal of `self.revalidating` in [previous PR](https://github.com/volueinsight/wapi-python/pull/110), there is no way to exit the calling loop, until it gets stack overflow with `RecursionError`.

This PR aims to break the loop by separating the `Session.data_request` function into 2 parts, then having `Auth.validate_auth` only calling the second part.