### PR TITLE
ci: Unittests on GHA

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,0 +1,39 @@
+name: unittests
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
+
+  push:
+    branches:
+      - development
+      - master
+
+jobs:
+  unittests:
+    timeout-minutes: 10
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [ '3.5', '3.6', '3.7', '3.8', '3.9' ]
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies ${{ matrix.python-version }}
+        run: |
+          REQS="-r requirements.txt -r test-requirements.txt"
+          pip install --upgrade --upgrade-strategy eager ${REQS}
+      - name: Print Python Version
+        run: python --version
+      - name: Run tests
+        run: |
+          python -m pytest -vv

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -32,8 +32,7 @@ jobs:
         run: |
           REQS="-r requirements.txt -r test-requirements.txt"
           pip install --upgrade --upgrade-strategy eager ${REQS}
-      - name: Print Python Version
-        run: python --version
+      
       - name: Run tests
         run: |
           python -m pytest -vv

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ https://api.wattsight.com/ (or equivalent services).  Note that access
 is based on some sort of login credentials, this library is not all
 that useful unless you have a valid Wattsight account.
 
-The library is tested against both Python 2.7 and Python 3.6,
-we recommend using Python 3.
+The library is tested against both Python version >=3.5 and <=3.9
 
 
 ## Documentation


### PR DESCRIPTION
Tested against Py version 3.5 to 3.9.
Current CI tests only on 3.9