### PR TITLE
feat: deprecate wapi-python for Py3.5

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5.1.1
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [ '3.5', '3.6', '3.7', '3.8', '3.9' ]
+        python-version: ['3.6', '3.7', '3.8', '3.9' ]
 
     steps:
       - name: Cancel Previous Runs
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5.1.1
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://api.volueinsight.com/ (or equivalent services).  Note that access
 is based on some sort of login credentials, this library is not all
 that useful unless you have a valid Wattsight account.
 
-The library is tested against both Python versions >=3.6 and <=3.9
+The library is tested against Python versions >=3.6 and <=3.9
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://api.volueinsight.com/ (or equivalent services).  Note that access
 is based on some sort of login credentials, this library is not all
 that useful unless you have a valid Wattsight account.
 
-The library is tested against both Python version >=3.5 and <=3.9
+The library is tested against both Python versions >=3.6 and <=3.9
 
 
 ## Documentation

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,7 +4,7 @@ Installation
 ============
 
 To use the Volue Insight API python library you need to have `Python`_ installed.
-The library is tested against both Python versions >=3.6 and <=3.9
+The library is tested against Python versions >=3.6 and <=3.9
 
 You can simply install/update the latest version of Volue Insight API python
 library with pip.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,8 +4,7 @@ Installation
 ============
 
 To use the Volue Insight API python library you need to have `Python`_ installed.
-The library is tested against both Python 2.7 and
-Python 3.6, we recommend using Python 3.
+The library is tested against both Python versions >=3.6 and <=3.9
 
 You can simply install/update the latest version of Volue Insight API python
 library with pip.


### PR DESCRIPTION
Unittest for 3.5 are failing because of dependencies no more supporting 3.5
Py3.5 has also reach EOL, so we should also stop supporting 3.5