### PR TITLE
fix: replaced minute shorthand T with min

### DIFF
--- a/wapi/util.py
+++ b/wapi/util.py
@@ -33,10 +33,10 @@ _TS_FREQ_TABLE = {
     'H12': '12H',
     'H6': '6H',
     'H3': '3H',
-    'MIN30': '30T',
-    'MIN15': '15T',
-    'MIN5': '5T',
-    'MIN': 'T',
+    'MIN30': '30min',
+    'MIN15': '15min',
+    'MIN5': '5min',
+    'MIN': 'min',
 }
 # Mapping from Pandas to TS is built from map above, with some additions
 _PANDAS_FREQ_TABLE = {


### PR DESCRIPTION
In version 2.2.3 pandas raises deprecation warnings when the shorthand `T` is used for minutes and recommends using `min` instead.

site-packages/wapi/util.py:135: FutureWarning: 'T' is deprecated and will be removed in a future version, please use 'min' instead.
  return res.asfreq(self._map_freq(self.frequency))