### PR TITLE
chore: update workflow ubuntu version

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   unittests:
     timeout-minutes: 10
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9' ]


### PR DESCRIPTION
# What
This updates the github actions runner image from ubuntu-20.04 -> ubuntu-24.04

# Why
GitHub Actions are closing down the runner image for ubuntu-20.04 on April 1st 2025.